### PR TITLE
Fix for Paladins not DPSing if set to by the user.

### DIFF
--- a/Singular/ClassSpecific/Paladin/Holy.cs
+++ b/Singular/ClassSpecific/Paladin/Holy.cs
@@ -73,7 +73,7 @@ namespace Singular.ClassSpecific.Paladin
         {
             return new PrioritySelector(
                 new Decorator(
-                    ret => !Unit.NearbyGroupMembers.Any(m => m.IsAlive && !m.IsMe),
+                    ret => HealerManager.AllowHealerDPS(),
                     new PrioritySelector(
                         Helpers.Common.EnsureReadyToAttackFromMelee(),
                         Spell.WaitForCastOrChannel(),


### PR DESCRIPTION
The AllowHealerDPS() bool allows us to determine if DPS should be done while in a context which healing is priority.
However, Holy Paladins were not abiding by this check.

This fix simply makes Holy Paladins abide by the check and DPS if the user wants it to.